### PR TITLE
chore(platform): Reformatted JWT token to standard `Authorized: Bearer (token)` format

### DIFF
--- a/apps/console/app/routes/apps/$clientId.tsx
+++ b/apps/console/app/routes/apps/$clientId.tsx
@@ -11,7 +11,6 @@ import toast, { Toaster } from 'react-hot-toast'
 import { requireJWT } from '~/utilities/session.server'
 import { getGalaxyClient } from '~/utilities/platform.server'
 import createStarbaseClient from '@kubelt/platform-clients/starbase'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 import type { appDetailsProps } from '~/components/Applications/Auth/ApplicationAuth'
 import { RotatedSecrets } from '~/types'
 import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
@@ -35,11 +34,10 @@ export const loader: LoaderFunction = async ({ request, params }) => {
   }
 
   const jwt = await requireJWT(request)
-  const starbaseClient = createStarbaseClient(Starbase, {
-    headers: {
-      [PlatformJWTAssertionHeader]: jwt,
-    },
-  })
+  const starbaseClient = createStarbaseClient(
+    Starbase,
+    getAuthzHeaderConditionallyFromToken(jwt)
+  )
   const galaxyClient = await getGalaxyClient()
 
   const clientId = params?.clientId

--- a/apps/console/app/routes/apps/$clientId/auth.tsx
+++ b/apps/console/app/routes/apps/$clientId/auth.tsx
@@ -20,11 +20,11 @@ import createStarbaseClient from '@kubelt/platform-clients/starbase'
 import { requireJWT } from '~/utilities/session.server'
 import { DeleteAppModal } from '~/components/DeleteAppModal/DeleteAppModal'
 import { useEffect, useState } from 'react'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 import { Loader } from '@kubelt/design-system/src/molecules/loader/Loader'
 
 import { z } from 'zod'
 import { RollType } from '~/types'
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 
 /**
  * @file app/routes/dashboard/index.tsx
@@ -114,11 +114,10 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     throw new Error('Application client id is required for the requested route')
   }
   const jwt = await requireJWT(request)
-  const starbaseClient = createStarbaseClient(Starbase, {
-    headers: {
-      [PlatformJWTAssertionHeader]: jwt,
-    },
-  })
+  const starbaseClient = createStarbaseClient(
+    Starbase,
+    getAuthzHeaderConditionallyFromToken(jwt)
+  )
 
   const scopeMeta = await starbaseClient.getScopes.query()
 
@@ -133,11 +132,10 @@ export const action: ActionFunction = async ({ request, params }) => {
   let rotatedSecret, updates
 
   const jwt = await requireJWT(request)
-  const starbaseClient = createStarbaseClient(Starbase, {
-    headers: {
-      [PlatformJWTAssertionHeader]: jwt,
-    },
-  })
+  const starbaseClient = createStarbaseClient(
+    Starbase,
+    getAuthzHeaderConditionallyFromToken(jwt)
+  )
 
   const formData = await request.formData()
   const op = formData.get('op')

--- a/apps/console/app/routes/apps/$clientId/index.tsx
+++ b/apps/console/app/routes/apps/$clientId/index.tsx
@@ -14,9 +14,9 @@ import invariant from 'tiny-invariant'
 import { ApplicationDashboard } from '~/components/Applications/Dashboard/ApplicationDashboard'
 import createStarbaseClient from '@kubelt/platform-clients/starbase'
 import { requireJWT } from '~/utilities/session.server'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 import type { appDetailsProps } from '~/components/Applications/Auth/ApplicationAuth'
 import { RollType, RotatedSecrets } from '~/types'
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 
 // Component
 // -----------------------------------------------------------------------------
@@ -30,11 +30,10 @@ export const action: ActionFunction = async ({ request, params }) => {
   }
 
   const jwt = await requireJWT(request)
-  const starbaseClient = createStarbaseClient(Starbase, {
-    headers: {
-      [PlatformJWTAssertionHeader]: jwt,
-    },
-  })
+  const starbaseClient = createStarbaseClient(
+    Starbase,
+    getAuthzHeaderConditionallyFromToken(jwt)
+  )
 
   const formData = await request.formData()
   const op = formData.get('op')
@@ -68,11 +67,10 @@ export const action: ActionFunction = async ({ request, params }) => {
 export default function AppDetailIndexPage() {
   const submit = useSubmit()
   const actionData = useActionData()
-  const outletContext =
-    useOutletContext<{
-      appDetails: appDetailsProps
-      rotationResult: RotatedSecrets
-    }>()
+  const outletContext = useOutletContext<{
+    appDetails: appDetailsProps
+    rotationResult: RotatedSecrets
+  }>()
   const navigate = useNavigate()
 
   const { appDetails: app } = outletContext

--- a/apps/console/app/routes/apps/delete.tsx
+++ b/apps/console/app/routes/apps/delete.tsx
@@ -1,7 +1,7 @@
 import { ActionFunction, json, redirect } from '@remix-run/cloudflare'
 import createStarbaseClient from '@kubelt/platform-clients/starbase'
 import { requireJWT } from '~/utilities/session.server'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 
 export const action: ActionFunction = async ({ request }) => {
   const formData = await request.formData()
@@ -11,11 +11,10 @@ export const action: ActionFunction = async ({ request }) => {
 
   const jwt = await requireJWT(request)
 
-  const starbaseClient = createStarbaseClient(Starbase, {
-    headers: {
-      [PlatformJWTAssertionHeader]: jwt,
-    },
-  })
+  const starbaseClient = createStarbaseClient(
+    Starbase,
+    getAuthzHeaderConditionallyFromToken(jwt)
+  )
   try {
     await starbaseClient.deleteApp.mutate({
       clientId,

--- a/apps/console/app/routes/apps/new.tsx
+++ b/apps/console/app/routes/apps/new.tsx
@@ -1,7 +1,7 @@
 import { ActionFunction, json, redirect } from '@remix-run/cloudflare'
 import createStarbaseClient from '@kubelt/platform-clients/starbase'
 import { requireJWT } from '~/utilities/session.server'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 
 export const action: ActionFunction = async ({ request }) => {
   const formData = await request.formData()
@@ -11,11 +11,10 @@ export const action: ActionFunction = async ({ request }) => {
 
   const jwt = await requireJWT(request)
 
-  const starbaseClient = createStarbaseClient(Starbase, {
-    headers: {
-      [PlatformJWTAssertionHeader]: jwt,
-    },
-  })
+  const starbaseClient = createStarbaseClient(
+    Starbase,
+    getAuthzHeaderConditionallyFromToken(jwt)
+  )
   try {
     const { clientId } = await starbaseClient.createApp.mutate({ clientName })
     console.log({ clientId })

--- a/apps/console/app/routes/dashboard/index.tsx
+++ b/apps/console/app/routes/dashboard/index.tsx
@@ -24,7 +24,6 @@ import { requireJWT } from '~/utilities/session.server'
 import { getGalaxyClient } from '~/utilities/platform.server'
 import { InfoPanelDashboard } from '~/components/InfoPanel/InfoPanelDashboard'
 import createStarbaseClient from '@kubelt/platform-clients/starbase'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 
 type LoaderData = {
@@ -40,11 +39,10 @@ type LoaderData = {
 
 export const loader: LoaderFunction = async ({ request }) => {
   const jwt = await requireJWT(request)
-  const starbaseClient = createStarbaseClient(Starbase, {
-    headers: {
-      [PlatformJWTAssertionHeader]: jwt,
-    },
-  })
+  const starbaseClient = createStarbaseClient(
+    Starbase,
+    getAuthzHeaderConditionallyFromToken(jwt)
+  )
 
   const galaxyClient = await getGalaxyClient()
   try {

--- a/apps/passport/app/platform.server.ts
+++ b/apps/passport/app/platform.server.ts
@@ -4,17 +4,14 @@ import createAddressClient from '@kubelt/platform-clients/address'
 import createStarbaseClient from '@kubelt/platform-clients/starbase'
 
 import { GraphQLClient } from 'graphql-request'
-import {
-  PlatformAddressURNHeader,
-  PlatformJWTAssertionHeader,
-} from '@kubelt/types/headers'
+import { PlatformAddressURNHeader } from '@kubelt/types/headers'
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 
 export function getStarbaseClient(jwt: string, env: Env) {
-  return createStarbaseClient(env.Starbase, {
-    headers: {
-      [PlatformJWTAssertionHeader]: jwt,
-    },
-  })
+  return createStarbaseClient(
+    env.Starbase,
+    getAuthzHeaderConditionallyFromToken(jwt)
+  )
 }
 
 export function getAccessClient(env: Env) {
@@ -22,12 +19,9 @@ export function getAccessClient(env: Env) {
 }
 
 export function getAddressClient(addressUrn: string, env: Env) {
-  const requestInit = {
-    headers: {
-      [PlatformAddressURNHeader]: addressUrn,
-    },
-  }
-  return createAddressClient(env.Address, requestInit)
+  return createAddressClient(env.Address, {
+    [PlatformAddressURNHeader]: addressUrn,
+  })
 }
 
 export async function getGalaxyClient() {

--- a/apps/passport/app/routes/authorize.tsx
+++ b/apps/passport/app/routes/authorize.tsx
@@ -1,5 +1,4 @@
 import { CryptoAddressType, OAuthAddressType } from '@kubelt/types/address'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 import { AddressURN } from '@kubelt/urns/address'
 import { json, LoaderFunction } from '@remix-run/cloudflare'
 import { Outlet, useLoaderData } from '@remix-run/react'

--- a/apps/passport/app/routes/userinfo.tsx
+++ b/apps/passport/app/routes/userinfo.tsx
@@ -1,11 +1,10 @@
-import { json, redirect } from '@remix-run/cloudflare'
+import { json } from '@remix-run/cloudflare'
 import type { LoaderFunction } from '@remix-run/cloudflare'
-import { requireJWT } from '~/session.server'
 import createAccessClient from '@kubelt/platform-clients/access'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
+import { getAuthzTokenFromReq } from '@kubelt/utils'
 
 export const loader: LoaderFunction = async ({ request, context }) => {
-  const access_token = request.headers.get(PlatformJWTAssertionHeader)
+  const access_token = getAuthzTokenFromReq(request)
   if (!access_token) throw json({ message: 'No access token provided' }, 403)
 
   const accessClient = createAccessClient(context.env.Access)

--- a/apps/profile/app/helpers/clients.ts
+++ b/apps/profile/app/helpers/clients.ts
@@ -1,7 +1,5 @@
 import { GraphQLClient } from 'graphql-request'
 import { getSdk } from '@kubelt/galaxy-client'
-import createAddressClient from '@kubelt/platform-clients/address'
-import { ClientOptions } from '@kubelt/platform-clients/types'
 
 export async function getGalaxyClient() {
   const gqlClient = new GraphQLClient('http://127.0.0.1', {
@@ -9,8 +7,4 @@ export async function getGalaxyClient() {
     fetch: Galaxy.fetch.bind(Galaxy),
   })
   return getSdk(gqlClient)
-}
-
-export function getCryptoAddressClient(options: ClientOptions) {
-  return createAddressClient(Address, options)
 }

--- a/packages/platform-clients/access.ts
+++ b/packages/platform-clients/access.ts
@@ -1,15 +1,14 @@
 import { createTRPCProxyClient, httpBatchLink } from '@trpc/client'
 import { Router } from '@kubelt/types'
-import { ClientOptions } from './types'
 
-export default (fetcher: Fetcher, options?: ClientOptions) =>
+export default (fetcher: Fetcher, headers?: Record<string, string>) =>
   createTRPCProxyClient<Router.AccessRouter>({
     links: [
       httpBatchLink({
         url: 'http://localhost/trpc',
         fetch: fetcher.fetch.bind(fetcher), // NOTE: preflight middleware?
         headers() {
-          return options?.headers || {}
+          return headers || {}
         },
       }),
     ],

--- a/packages/platform-clients/account.ts
+++ b/packages/platform-clients/account.ts
@@ -1,15 +1,14 @@
 import { createTRPCProxyClient, httpBatchLink } from '@trpc/client'
 import { Router } from '@kubelt/types'
-import { ClientOptions } from './types'
 
-export default (fetcher: Fetcher, options?: ClientOptions) =>
+export default (fetcher: Fetcher, headers?: Record<string, string>) =>
   createTRPCProxyClient<Router.AccountRouter>({
     links: [
       httpBatchLink({
         url: 'http://localhost/trpc',
         fetch: fetcher.fetch.bind(fetcher), // NOTE: preflight middleware?
         headers() {
-          return options?.headers || {}
+          return headers || {}
         },
       }),
     ],

--- a/packages/platform-clients/address.ts
+++ b/packages/platform-clients/address.ts
@@ -1,15 +1,14 @@
 import { createTRPCProxyClient, httpBatchLink } from '@trpc/client'
 import { Router } from '@kubelt/types'
-import { ClientOptions } from './types'
 
-export default (fetcher: Fetcher, options?: ClientOptions) =>
+export default (fetcher: Fetcher, headers?: Record<string, string>) =>
   createTRPCProxyClient<Router.AddressRouter>({
     links: [
       httpBatchLink({
         url: 'http://localhost/trpc',
         fetch: fetcher.fetch.bind(fetcher), // NOTE: preflight middleware?
         headers() {
-          return options?.headers || {}
+          return headers || {}
         },
       }),
     ],

--- a/packages/platform-clients/edges.ts
+++ b/packages/platform-clients/edges.ts
@@ -1,15 +1,14 @@
 import { createTRPCProxyClient, httpBatchLink } from '@trpc/client'
 import { Router } from '@kubelt/types'
-import { ClientOptions } from './types'
 
-export default (fetcher: Fetcher, options?: ClientOptions) =>
+export default (fetcher: Fetcher, headers?: Record<string, string>) =>
   createTRPCProxyClient<Router.EdgesRouter>({
     links: [
       httpBatchLink({
         url: 'http://localhost/trpc',
         fetch: fetcher.fetch.bind(fetcher), // NOTE: preflight middleware?
         headers() {
-          return options?.headers || {}
+          return headers || {}
         },
       }),
     ],

--- a/packages/platform-clients/image.ts
+++ b/packages/platform-clients/image.ts
@@ -1,15 +1,14 @@
 import { createTRPCProxyClient, httpBatchLink } from '@trpc/client'
 import { Router } from '@kubelt/types'
-import { ClientOptions } from './types'
 
-export default (fetcher: Fetcher, options?: ClientOptions) =>
+export default (fetcher: Fetcher, headers?: Record<string, string>) =>
   createTRPCProxyClient<Router.ImageRouter>({
     links: [
       httpBatchLink({
         url: 'http://localhost/trpc',
         fetch: fetcher.fetch.bind(fetcher), // NOTE: preflight middleware?
         headers() {
-          return options?.headers || {}
+          return headers || {}
         },
       }),
     ],

--- a/packages/platform-clients/object.ts
+++ b/packages/platform-clients/object.ts
@@ -1,15 +1,14 @@
 import { createTRPCProxyClient, httpBatchLink } from '@trpc/client'
 import { Router } from '@kubelt/types'
-import { ClientOptions } from './types'
 
-export default (fetcher: Fetcher, options?: ClientOptions) =>
+export default (fetcher: Fetcher, headers?: Record<string, string>) =>
   createTRPCProxyClient<Router.ObjectRouter>({
     links: [
       httpBatchLink({
         url: 'http://localhost/trpc',
         fetch: fetcher.fetch.bind(fetcher), // NOTE: preflight middleware?
         headers() {
-          return options?.headers || {}
+          return headers || {}
         },
       }),
     ],

--- a/packages/platform-clients/ping.ts
+++ b/packages/platform-clients/ping.ts
@@ -1,15 +1,14 @@
 import { createTRPCProxyClient, httpBatchLink } from '@trpc/client'
 import { Router } from '@kubelt/types'
-import { ClientOptions } from './types'
 
-export default (fetcher: Fetcher, options?: ClientOptions) =>
+export default (fetcher: Fetcher, headers?: Record<string, string>) =>
   createTRPCProxyClient<Router.PingRouter>({
     links: [
       httpBatchLink({
         url: 'http://localhost/trpc',
         fetch: fetcher.fetch,
         headers() {
-          return options?.headers || {}
+          return headers || {}
         },
       }),
     ],

--- a/packages/platform-clients/starbase.ts
+++ b/packages/platform-clients/starbase.ts
@@ -1,15 +1,14 @@
 import { createTRPCProxyClient, httpBatchLink } from '@trpc/client'
 import { Router } from '@kubelt/types'
-import { ClientOptions } from './types'
 
-export default (fetcher: Fetcher, options?: ClientOptions) =>
+export default (fetcher: Fetcher, headers?: Record<string, string>) =>
   createTRPCProxyClient<Router.StarbaseRouter>({
     links: [
       httpBatchLink({
         url: 'http://localhost/trpc',
         fetch: fetcher.fetch.bind(fetcher), // NOTE: preflight middleware?
         headers() {
-          return options?.headers || {}
+          return headers ?? {}
         },
       }),
     ],

--- a/packages/platform-clients/types.ts
+++ b/packages/platform-clients/types.ts
@@ -1,3 +1,0 @@
-export type ClientOptions = {
-  headers?: Record<string, string>
-}

--- a/packages/platform-middleware/jwt.ts
+++ b/packages/platform-middleware/jwt.ts
@@ -1,14 +1,13 @@
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 import type { AccountURN } from '@kubelt/urns/account'
 import { AccountURNSpace } from '@kubelt/urns/account'
 import * as jose from 'jose'
 import { BaseMiddlewareFunction } from './types'
+import { getAuthzTokenFromReq } from '@kubelt/utils'
 
-export const JWTAssertionTokenFromHeader: BaseMiddlewareFunction<{
+export const AuthorizationTokenFromHeader: BaseMiddlewareFunction<{
   req?: Request
 }> = ({ ctx, next }) => {
-  const headers = ctx.req?.headers
-  const token = headers?.get(PlatformJWTAssertionHeader)
+  const token = ctx.req ? getAuthzTokenFromReq(ctx.req) : undefined
   return next({
     ctx: {
       ...ctx,

--- a/packages/types/headers.ts
+++ b/packages/types/headers.ts
@@ -1,2 +1,1 @@
-export const PlatformJWTAssertionHeader = 'rollup-access-jwt-assertion'
 export const PlatformAddressURNHeader = 'rollup-address-urn'

--- a/packages/utils/getAuthzHeaderConditionallyFromToken.ts
+++ b/packages/utils/getAuthzHeaderConditionallyFromToken.ts
@@ -1,3 +1,3 @@
-export default function (token: string | undefined): HeadersInit {
+export default function (token: string | undefined): Record<string, string> {
   return token ? { Authorization: `Bearer ${token}` } : {}
 }

--- a/platform/access/src/jsonrpc/router.ts
+++ b/platform/access/src/jsonrpc/router.ts
@@ -6,7 +6,7 @@ import { InjectEdges } from '@kubelt/platform-middleware/edges'
 
 import {
   ValidateJWT,
-  JWTAssertionTokenFromHeader,
+  AuthorizationTokenFromHeader,
   RequireAccount,
 } from '@kubelt/platform-middleware/jwt'
 
@@ -70,7 +70,7 @@ export const appRouter = t.router({
     .output(VerifyAuthorizationMethodOutput)
     .query(verifyAuthorizationMethod),
   getSession: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(RequireAccount)
     .use(setAccessNode)
@@ -80,7 +80,7 @@ export const appRouter = t.router({
     .output(GetSessionMethodOutput)
     .query(getSessionMethod),
   revokeSession: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(RequireAccount)
     .use(InjectEdges)

--- a/platform/account/src/jsonrpc/router.ts
+++ b/platform/account/src/jsonrpc/router.ts
@@ -24,7 +24,7 @@ import { getAddressesMethod } from './methods/getAddresses'
 
 import {
   ValidateJWT,
-  JWTAssertionTokenFromHeader,
+  AuthorizationTokenFromHeader,
 } from '@kubelt/platform-middleware/jwt'
 import { LogUsage } from '@kubelt/platform-middleware/log'
 import { Scopes } from '@kubelt/platform-middleware/scopes'
@@ -77,7 +77,7 @@ export const injectAccountNode = t.middleware(async ({ ctx, next }) => {
 
 export const appRouter = t.router({
   getProfile: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(Scopes)
     .use(LogUsage)
     .use(Analytics)
@@ -85,7 +85,7 @@ export const appRouter = t.router({
     .output(GetProfileOutput)
     .query(getProfileMethod),
   setProfile: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(Scopes)
     .use(injectAccountNode)
@@ -94,7 +94,7 @@ export const appRouter = t.router({
     .input(SetProfileInput)
     .mutation(setProfileMethod),
   getLinks: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(Scopes)
     .use(LogUsage)
     .use(Analytics)
@@ -102,7 +102,7 @@ export const appRouter = t.router({
     .output(GetLinksOutput)
     .query(getLinksMethod),
   setLinks: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(Scopes)
     .use(injectAccountNode)
@@ -111,7 +111,7 @@ export const appRouter = t.router({
     .input(SetLinksInput)
     .mutation(setLinksMethod),
   getGallery: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(Scopes)
     .use(LogUsage)
     .use(Analytics)
@@ -119,7 +119,7 @@ export const appRouter = t.router({
     .output(GetGalleryOutput)
     .query(getGalleryMethod),
   setGallery: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(Scopes)
     .use(injectAccountNode)
@@ -128,7 +128,7 @@ export const appRouter = t.router({
     .input(SetGalleryInput)
     .mutation(setGalleryMethod),
   getAddresses: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(Scopes)
     .use(LogUsage)
     .use(Analytics)
@@ -136,7 +136,7 @@ export const appRouter = t.router({
     // .output(AddressListSchema)
     .query(getAddressesMethod),
   getOwnAddresses: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(Scopes)
     .use(LogUsage)
@@ -151,7 +151,7 @@ export const appRouter = t.router({
     // .output(AddressListSchema)
     .query(getPublicAddressesMethod),
   hasAddresses: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(Scopes)
     .use(LogUsage)
@@ -159,7 +159,7 @@ export const appRouter = t.router({
     .input(HasAddressesInput)
     .mutation(hasAddressesMethod),
   getSessions: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(Scopes)
     .use(LogUsage)

--- a/platform/address/src/jsonrpc/methods/unsetAccount.ts
+++ b/platform/address/src/jsonrpc/methods/unsetAccount.ts
@@ -33,7 +33,7 @@ export const unsetAccountMethod = async ({
   const edgesClient = getEdgesClient(ctx.Edges)
   const nodeClient = ctx.address
 
-  // Get the address associated with the PlatformJWTAssertionHeader included in the request.
+  // Get the address associated with the authorization header included in the request.
   const address = ctx.addressURN as AddressURN
 
   const account = input

--- a/platform/galaxy/src/schema/resolvers/account.ts
+++ b/platform/galaxy/src/schema/resolvers/account.ts
@@ -19,10 +19,8 @@ import { AddressURN, AddressURNSpace } from '@kubelt/urns/address'
 import { NodeType } from '@kubelt/types/address'
 import { Gallery, Links, Profile } from '@kubelt/platform.account/src/types'
 import { ResolverContext } from './common'
-import {
-  PlatformAddressURNHeader,
-  PlatformJWTAssertionHeader,
-} from '@kubelt/types/headers'
+import { PlatformAddressURNHeader } from '@kubelt/types/headers'
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 
 const accountResolvers: Resolvers = {
   Query: {
@@ -34,13 +32,7 @@ const accountResolvers: Resolvers = {
       console.log(`galaxy:profile: getting profile for account: ${accountURN}`)
       const accountClient = createAccountClient(
         env.Account,
-        jwt
-          ? {
-              headers: {
-                [PlatformJWTAssertionHeader]: jwt,
-              },
-            }
-          : {}
+        getAuthzHeaderConditionallyFromToken(jwt)
       )
       let accountProfile = await accountClient.getProfile.query({
         account: accountURN,
@@ -56,11 +48,10 @@ const accountResolvers: Resolvers = {
       { env, accountURN, jwt }: ResolverContext
     ) => {
       console.log(`galaxy:links: getting links for account: ${accountURN}`)
-      const accountClient = createAccountClient(env.Account, {
-        headers: {
-          [PlatformJWTAssertionHeader]: jwt,
-        },
-      })
+      const accountClient = createAccountClient(
+        env.Account,
+        getAuthzHeaderConditionallyFromToken(jwt)
+      )
       let links = await accountClient.getLinks.query({
         account: accountURN,
       })
@@ -76,13 +67,7 @@ const accountResolvers: Resolvers = {
       console.log(`galaxy:gallery: getting gallery for account: ${accountURN}`)
       const accountClient = createAccountClient(
         env.Account,
-        jwt
-          ? {
-              headers: {
-                [PlatformJWTAssertionHeader]: jwt,
-              },
-            }
-          : {}
+        getAuthzHeaderConditionallyFromToken(jwt)
       )
 
       let gallery = await accountClient.getGallery.query({
@@ -112,9 +97,7 @@ const accountResolvers: Resolvers = {
       { env, jwt }: ResolverContext
     ) => {
       const addressClient = createAddressClient(env.Address, {
-        headers: {
-          [PlatformAddressURNHeader]: addressURN, // note: ens names will be resolved
-        },
+        [PlatformAddressURNHeader]: addressURN, // note: ens names will be resolved
       })
       const accountURN = await addressClient.getAccount.query()
 
@@ -129,13 +112,7 @@ const accountResolvers: Resolvers = {
       // get the account profile
       const accountClient = createAccountClient(
         env.Account,
-        jwt
-          ? {
-              headers: {
-                [PlatformJWTAssertionHeader]: jwt,
-              },
-            }
-          : {}
+        getAuthzHeaderConditionallyFromToken(jwt)
       )
 
       console.log("galaxy.profileFromAddress: getting account's profile")
@@ -174,9 +151,7 @@ const accountResolvers: Resolvers = {
       { env, jwt }: ResolverContext
     ) => {
       const addressClient = createAddressClient(env.Address, {
-        headers: {
-          [PlatformAddressURNHeader]: addressURN, // note: ens names will be resolved
-        },
+        [PlatformAddressURNHeader]: addressURN, // note: ens names will be resolved
       })
       const accountURN = await addressClient.getAccount.query()
 
@@ -191,13 +166,7 @@ const accountResolvers: Resolvers = {
       // get the account profile
       const accountClient = createAccountClient(
         env.Account,
-        jwt
-          ? {
-              headers: {
-                [PlatformJWTAssertionHeader]: jwt,
-              },
-            }
-          : {}
+        getAuthzHeaderConditionallyFromToken(jwt)
       )
 
       console.log("galaxy.linksFromAddress: getting account's links")
@@ -215,9 +184,7 @@ const accountResolvers: Resolvers = {
       { env, jwt }: ResolverContext
     ) => {
       const addressClient = createAddressClient(env.Address, {
-        headers: {
-          [PlatformAddressURNHeader]: addressURN, // note: ens names will be resolved
-        },
+        [PlatformAddressURNHeader]: addressURN, // note: ens names will be resolved
       })
       const accountURN = await addressClient.getAccount.query()
 
@@ -232,13 +199,7 @@ const accountResolvers: Resolvers = {
       // get the account profile
       const accountClient = createAccountClient(
         env.Account,
-        jwt
-          ? {
-              headers: {
-                [PlatformJWTAssertionHeader]: jwt,
-              },
-            }
-          : {}
+        getAuthzHeaderConditionallyFromToken(jwt)
       )
 
       console.log("galaxy.galleryFromAddress: getting account's gallery")
@@ -256,9 +217,7 @@ const accountResolvers: Resolvers = {
       { env, jwt }: ResolverContext
     ) => {
       const addressClient = createAddressClient(env.Address, {
-        headers: {
-          [PlatformAddressURNHeader]: addressURN, // note: ens names will be resolved
-        },
+        [PlatformAddressURNHeader]: addressURN, // note: ens names will be resolved
       })
       const accountURN = await addressClient.getAccount.query()
 
@@ -293,11 +252,10 @@ const accountResolvers: Resolvers = {
         `galaxy.updateProfile: updating profile for account: ${accountURN}`
       )
 
-      const accountClient = createAccountClient(env.Account, {
-        headers: {
-          [PlatformJWTAssertionHeader]: jwt,
-        },
-      })
+      const accountClient = createAccountClient(
+        env.Account,
+        getAuthzHeaderConditionallyFromToken(jwt)
+      )
       let currentProfile = await accountClient.getProfile.query({
         account: accountURN,
       })
@@ -323,11 +281,10 @@ const accountResolvers: Resolvers = {
         `galaxy.updateProfile: updating profile for account: ${accountURN}`
       )
 
-      const accountClient = createAccountClient(env.Account, {
-        headers: {
-          [PlatformJWTAssertionHeader]: jwt,
-        },
-      })
+      const accountClient = createAccountClient(
+        env.Account,
+        getAuthzHeaderConditionallyFromToken(jwt)
+      )
 
       await accountClient.setLinks.mutate({
         name: accountURN,
@@ -345,11 +302,10 @@ const accountResolvers: Resolvers = {
         `galaxy.updateProfile: updating profile for account: ${accountURN}`
       )
 
-      const accountClient = createAccountClient(env.Account, {
-        headers: {
-          [PlatformJWTAssertionHeader]: jwt,
-        },
-      })
+      const accountClient = createAccountClient(
+        env.Account,
+        getAuthzHeaderConditionallyFromToken(jwt)
+      )
 
       const connectedAddresses = (
         (await getConnectedAddresses({

--- a/platform/galaxy/src/schema/resolvers/address.ts
+++ b/platform/galaxy/src/schema/resolvers/address.ts
@@ -4,7 +4,7 @@ import createAddressClient from '@kubelt/platform-clients/address'
 import { AddressURN } from '@kubelt/urns/address'
 
 import { AddressProfilesUnion, Resolvers } from './typedefs'
-import { hasApiKey, setupContext, logAnalytics, isAuthorized } from './utils'
+import { hasApiKey, setupContext, isAuthorized } from './utils'
 
 import { ResolverContext } from './common'
 
@@ -29,9 +29,7 @@ const addressResolvers: Resolvers = {
       { env }: ResolverContext
     ) => {
       const addressClient = createAddressClient(env.Address, {
-        headers: {
-          [PlatformAddressURNHeader]: addressURN,
-        },
+        [PlatformAddressURNHeader]: addressURN,
       })
 
       const addressProfile = await addressClient.getAddressProfile.query()
@@ -46,9 +44,7 @@ const addressResolvers: Resolvers = {
       const profiles = await Promise.all(
         addressURNList.map(async (urn) => {
           const addressClient = createAddressClient(env.Address, {
-            headers: {
-              [PlatformAddressURNHeader]: urn,
-            },
+            [PlatformAddressURNHeader]: urn,
           })
 
           return addressClient.getAddressProfile.query()
@@ -65,9 +61,7 @@ const addressResolvers: Resolvers = {
       { env }: ResolverContext
     ) => {
       const addressClient = createAddressClient(env.Address, {
-        headers: {
-          [PlatformAddressURNHeader]: addressURN,
-        },
+        [PlatformAddressURNHeader]: addressURN,
       })
 
       await addressClient.setNickname.query({

--- a/platform/galaxy/src/schema/resolvers/nfts.ts
+++ b/platform/galaxy/src/schema/resolvers/nfts.ts
@@ -1,30 +1,22 @@
 import { composeResolvers } from '@graphql-tools/resolvers-composition'
 import { GraphQLYogaError } from '@graphql-yoga/common'
-import createAccountClient from '@kubelt/platform-clients/account'
 
-import { AddressURN, AddressURNSpace } from '@kubelt/urns/address'
-import { AccountURN, AccountURNSpace } from '@kubelt/urns/account'
+import { AddressURN } from '@kubelt/urns/address'
+import { AccountURNSpace } from '@kubelt/urns/account'
 
 import { Resolvers } from './typedefs'
-import { Profile } from '@kubelt/platform.account/src/types'
 import Env from '../../env'
 import {
   AlchemyChain,
-  AlchemyClient,
-  AlchemyClientConfig,
   NFTPropertyMapper,
 } from '../../../../../packages/alchemy-client'
 
 import { NodeType } from '@kubelt/types/address'
 
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
-
 import {
   hasApiKey,
   setupContext,
-  sliceIntoChunks,
   logAnalytics,
-  logNFTBatchAnalytics,
   getAllNfts,
   getAlchemyClients,
   nftBatchesFetcher,

--- a/platform/galaxy/src/schema/resolvers/utils/index.ts
+++ b/platform/galaxy/src/schema/resolvers/utils/index.ts
@@ -7,8 +7,11 @@ import createStarbaseClient from '@kubelt/platform-clients/starbase'
 import createAccountClient from '@kubelt/platform-clients/account'
 
 import Env from '../../../env'
-import { getAuthzTokenFromReq, isFromCFBinding } from '@kubelt/utils'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
+import {
+  getAuthzHeaderConditionallyFromToken,
+  getAuthzTokenFromReq,
+  isFromCFBinding,
+} from '@kubelt/utils'
 
 import { WriteAnalyticsDataPoint } from '@kubelt/packages/platform-clients/analytics'
 export {
@@ -190,13 +193,7 @@ export const getConnectedAddresses = async ({
 }) => {
   const accountClient = createAccountClient(
     Account,
-    jwt
-      ? {
-          headers: {
-            [PlatformJWTAssertionHeader]: jwt,
-          },
-        }
-      : {}
+    getAuthzHeaderConditionallyFromToken(jwt)
   )
 
   const addresses = await accountClient.getAddresses.query({

--- a/platform/starbase/src/jsonrpc/router.ts
+++ b/platform/starbase/src/jsonrpc/router.ts
@@ -8,7 +8,7 @@ import {
   CreateAppOutputSchema,
 } from './methods/createApp'
 import {
-  JWTAssertionTokenFromHeader,
+  AuthorizationTokenFromHeader,
   ValidateJWT,
 } from '@kubelt/platform-middleware/jwt'
 import { deleteApp, DeleteAppInput } from './methods/deleteApp'
@@ -64,7 +64,7 @@ const t = initTRPC.context<Context>().create()
 
 export const appRouter = t.router({
   createApp: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(LogUsage)
     .use(Analytics)
@@ -72,7 +72,7 @@ export const appRouter = t.router({
     .output(CreateAppOutputSchema)
     .mutation(createApp),
   deleteApp: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(LogUsage)
     .use(Analytics)
@@ -80,7 +80,7 @@ export const appRouter = t.router({
     .input(DeleteAppInput)
     .mutation(deleteApp),
   updateApp: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(LogUsage)
     .use(Analytics)
@@ -88,7 +88,7 @@ export const appRouter = t.router({
     .input(UpdateAppInput)
     .mutation(updateApp),
   getAppDetails: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(LogUsage)
     .use(Analytics)
@@ -97,7 +97,7 @@ export const appRouter = t.router({
     .output(GetAppDetailsOutput)
     .query(getAppDetails),
   getAppProfile: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(LogUsage)
     .use(Analytics)
@@ -106,7 +106,7 @@ export const appRouter = t.router({
     .output(GetAppProfileOutput)
     .query(getAppProfile),
   listApps: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(LogUsage)
     .use(Analytics)
@@ -115,7 +115,7 @@ export const appRouter = t.router({
     .output(ListAppsOutput)
     .query(listApps),
   rotateClientSecret: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(LogUsage)
     .use(Analytics)
@@ -124,7 +124,7 @@ export const appRouter = t.router({
     .output(RotateClientSecretOutput)
     .mutation(rotateClientSecret),
   rotateApiKey: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(LogUsage)
     .use(Analytics)
@@ -145,7 +145,7 @@ export const appRouter = t.router({
     .output(GetAppPublicPropsOutput)
     .query(getAppPublicProps),
   publishApp: t.procedure
-    .use(JWTAssertionTokenFromHeader)
+    .use(AuthorizationTokenFromHeader)
     .use(ValidateJWT)
     .use(LogUsage)
     .use(Analytics)


### PR DESCRIPTION
# Description

Renamed authorization token format to `Authorization: Bearer (token)`. This lines up with change made in Galaxy under #1555

- Closes #1568

## Type of change

- Chore 

# How Has This Been Tested?

- Wallet and OAuth (github) accounts: Profile (Public & signed-on profiles, settings, links and connected accounts) and Console (view existing apps, create new and delete)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
