### PR TITLE
feat(edge): Add created timestamp column on edges using drizzle migration

### DIFF
--- a/platform/edges/drizzle/20230208183719/migration.sql
+++ b/platform/edges/drizzle/20230208183719/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE edge ADD `createdTimestamp` text;

--- a/platform/edges/drizzle/20230208183719/snapshot.json
+++ b/platform/edges/drizzle/20230208183719/snapshot.json
@@ -1,0 +1,246 @@
+{
+  "version": "4",
+  "dialect": "sqlite",
+  "id": "cf43a793-63a5-405a-b14e-363ac2594743",
+  "prevId": "f101c24f-261c-4f0b-b56c-9e6f1cef4ad6",
+  "tables": {
+    "edge": {
+      "name": "edge",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dst": {
+          "name": "dst",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdTimestamp": {
+          "name": "createdTimestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "edge_src_node_urn_fk": {
+          "name": "edge_src_node_urn_fk",
+          "tableFrom": "edge",
+          "tableTo": "node",
+          "columnsFrom": [
+            "src"
+          ],
+          "columnsTo": [
+            "urn"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "edge_dst_node_urn_fk": {
+          "name": "edge_dst_node_urn_fk",
+          "tableFrom": "edge",
+          "tableTo": "node",
+          "columnsFrom": [
+            "dst"
+          ],
+          "columnsTo": [
+            "urn"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edge_src_dst_tag_pk": {
+          "columns": [
+            "src",
+            "dst",
+            "tag"
+          ]
+        }
+      }
+    },
+    "node": {
+      "name": "node",
+      "columns": {
+        "urn": {
+          "name": "urn",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nid": {
+          "name": "nid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nss": {
+          "name": "nss",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fragment": {
+          "name": "fragment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {}
+    },
+    "node_qcomp": {
+      "name": "node_qcomp",
+      "columns": {
+        "nodeUrn": {
+          "name": "nodeUrn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_node_qcomp_nodeUrn": {
+          "name": "IDX_node_qcomp_nodeUrn",
+          "columns": [
+            "nodeUrn"
+          ],
+          "isUnique": false
+        },
+        "IDX_node_qcomp_key": {
+          "name": "IDX_node_qcomp_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "IDX_node_qcomp_value": {
+          "name": "IDX_node_qcomp_value",
+          "columns": [
+            "value"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "node_qcomp_nodeUrn_node_urn_fk": {
+          "name": "node_qcomp_nodeUrn_node_urn_fk",
+          "tableFrom": "node_qcomp",
+          "tableTo": "node",
+          "columnsFrom": [
+            "nodeUrn"
+          ],
+          "columnsTo": [
+            "urn"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "node_qcomp_nodeUrn_key_pk": {
+          "columns": [
+            "nodeUrn",
+            "key"
+          ]
+        }
+      }
+    },
+    "node_rcomp": {
+      "name": "node_rcomp",
+      "columns": {
+        "nodeUrn": {
+          "name": "nodeUrn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_node_rcomp_nodeUrn": {
+          "name": "IDX_node_rcomp_nodeUrn",
+          "columns": [
+            "nodeUrn"
+          ],
+          "isUnique": false
+        },
+        "IDX_node_rcomp_key": {
+          "name": "IDX_node_rcomp_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "IDX_node_rcomp_value": {
+          "name": "IDX_node_rcomp_value",
+          "columns": [
+            "value"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "node_rcomp_nodeUrn_node_urn_fk": {
+          "name": "node_rcomp_nodeUrn_node_urn_fk",
+          "tableFrom": "node_rcomp",
+          "tableTo": "node",
+          "columnsFrom": [
+            "nodeUrn"
+          ],
+          "columnsTo": [
+            "urn"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "node_rcomp_nodeUrn_key_pk": {
+          "columns": [
+            "nodeUrn",
+            "key"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {}
+}

--- a/platform/edges/migrations/0001_adding_creationtimestamp.sql
+++ b/platform/edges/migrations/0001_adding_creationtimestamp.sql
@@ -1,0 +1,1 @@
+ALTER TABLE edge ADD `createdTimestamp` text;

--- a/platform/edges/src/db/insert.ts
+++ b/platform/edges/src/db/insert.ts
@@ -114,12 +114,14 @@ export async function edge(
       INSERT INTO edge (
         src,
         dst,
-        tag
+        tag,
+        createdTimestamp
       )
       VALUES (
         ?1,
         ?2,
-        ?3
+        ?3,
+        datetime('now')
       )
       ON CONFLICT DO NOTHING
     `

--- a/platform/edges/src/db/schema.ts
+++ b/platform/edges/src/db/schema.ts
@@ -35,6 +35,7 @@ export type EdgeTable = {
   src: NodeTable
   dst: NodeTable
   tag: string
+  createdTimestamp: string | null
 }
 
 export const node = sqliteTable('node', {
@@ -60,6 +61,7 @@ export const edge = sqliteTable(
         onDelete: 'no action',
         onUpdate: 'no action',
       }),
+    createdTimestamp: text('createdTimestamp'),
   },
   (table) => ({
     edge: primaryKey(table.src, table.dst, table.tag),

--- a/platform/edges/src/db/select.ts
+++ b/platform/edges/src/db/select.ts
@@ -310,7 +310,7 @@ export async function edges(
       const dst: Node = { ...dstNode, id: `urn:${dstNode.nid}:${dstNode.nss}` }
 
       const tag = edgeRec.tag
-      const createdTimestamp = edgeRec.createdTimestamp
+      const createdTimestamp = edgeRec.createdTimestamp || null
 
       return {
         tag,

--- a/platform/edges/src/db/select.ts
+++ b/platform/edges/src/db/select.ts
@@ -171,10 +171,10 @@ export async function edges(
 
   // Filter edges by tag, if provided.
   if (query.tag) {
-    sql = [sql, 'e.tag = ?2'].join(' AND ')
-
+    sql += ' AND e.tag = ?2 ORDER BY createdTimestamp ASC'
     statement = g.db.prepare(sql).bind(query.id.toString(), query.tag)
   } else {
+    sql += ' ORDER BY createdTimestamp ASC'
     statement = g.db.prepare(sql).bind(query.id.toString())
   }
 
@@ -310,11 +310,13 @@ export async function edges(
       const dst: Node = { ...dstNode, id: `urn:${dstNode.nid}:${dstNode.nss}` }
 
       const tag = edgeRec.tag
+      const createdTimestamp = edgeRec.createdTimestamp
 
       return {
         tag,
         src,
         dst,
+        createdTimestamp,
       }
     })
   )

--- a/platform/edges/src/db/types.ts
+++ b/platform/edges/src/db/types.ts
@@ -60,6 +60,8 @@ export interface EdgeRecord {
   dst: AnyURN
   // The "type" of the edge.
   tag: EdgeTag
+  // As the name suggests, created datetimestamp of the edge
+  createdTimestamp?: string
 }
 
 export interface QComponent {

--- a/platform/edges/src/jsonrpc/validators/edge.ts
+++ b/platform/edges/src/jsonrpc/validators/edge.ts
@@ -20,4 +20,5 @@ export const Edge = z.object({
   src: Node,
   dst: Node,
   tag: EdgeTagInput,
+  createdTimestamp: z.string().nullable(),
 })


### PR DESCRIPTION
# Description

Adds `createdTimestamp` column to `edge` table as well as exposes a field by the same name in the edge records returned by edge queries. The value of this field is set to a UTC representation of the edge creation time.

- Closes #1599

## Type of change


- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Ensuring date is entered in the local .sqlite DB for new edges, eg. when you create a new app in Console
- Ensuring the value comes through when retrieving that edge, eg. when listing apps.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
