### PR TITLE
fix(profile): compare the expiration time in milliseconds

### DIFF
--- a/apps/profile/app/utils/session.server.tsx
+++ b/apps/profile/app/utils/session.server.tsx
@@ -66,7 +66,7 @@ export async function requireJWT(request: Request, headers = new Headers()) {
     const parsedToken = parseJwt(accessToken)
 
     // if expired throw an error (we can extends Error to create this)
-    if (!parsedToken.exp || parsedToken.exp <= Date.now()) {
+    if (!parsedToken.exp || parsedToken.exp * 1000 <= Date.now()) {
       throw new AuthorizationError('Expired')
     }
 


### PR DESCRIPTION
# Description

The token expiration time is in seconds and `Date.now()` returns time in
milliseconds. The comparison results in expiration always because of that.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Manual