### PR TITLE
fix(passport): Reversing sideEffect flag from previous commit

### DIFF
--- a/apps/passport/package.json
+++ b/apps/passport/package.json
@@ -2,7 +2,7 @@
   "name": "@kubelt/apps.passport",
   "version": "0.1.0",
   "private": true,
-  "sideEffects": false,
+  "sideEffects": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 0",
     "build": "run-s 'build:*'",


### PR DESCRIPTION
# Description

Previous commit included the disabling of the sideEffect flag for Passport, which led to funky fetch handler errors when the first request was recieved by passport. This reverses that change.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Running Passport locally and being able to login through any provider without error.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
